### PR TITLE
directive for cspTrustedSite

### DIFF
--- a/src/main/default/cspTrustedSites/googleapis.cspTrustedSite-meta.xml
+++ b/src/main/default/cspTrustedSites/googleapis.cspTrustedSite-meta.xml
@@ -4,9 +4,4 @@
     <endpointUrl>https://chart.googleapis.com</endpointUrl>
     <isActive>true</isActive>
     <isApplicableToConnectSrc>true</isApplicableToConnectSrc>
-    <isApplicableToFontSrc>true</isApplicableToFontSrc>
-    <isApplicableToFrameSrc>true</isApplicableToFrameSrc>
-    <isApplicableToImgSrc>true</isApplicableToImgSrc>
-    <isApplicableToMediaSrc>false</isApplicableToMediaSrc>
-    <isApplicableToStyleSrc>true</isApplicableToStyleSrc>
 </CspTrustedSite>


### PR DESCRIPTION
Fix for Error  src/main/default/cspTrustedSites/googleapis.cspTrustedSite-meta.xml  Select at least one directive for which the site is allowed.
ERROR running force:source:push:  Push failed.